### PR TITLE
Style/global-styles

### DIFF
--- a/src/components/ArticleSummaryCard.astro
+++ b/src/components/ArticleSummaryCard.astro
@@ -1,18 +1,40 @@
 ---
 import Tag from "./Tag.astro";
 
-const { title, tags, slug, description } = Astro.props;
+const { title, tags, slug } = Astro.props;
 ---
 
 <article
-  class="my-9 rounded-3xl border border-indigo-700/30 bg-brand-primaryLight p-8 px-16 shadow-sm shadow-indigo-700/5 transition-all hover:ml-4 hover:border-indigo-700 hover:bg-indigo-900/30 hover:shadow-md hover:shadow-indigo-700/20"
+  class="group/card hover:border-secondary bg-brand-primary-dark/51  rounded-3xl border-transparent  bg-brand-primary-dark p-4 transition-all border-4 hover:border-brand-accent hover:bg-brand-primary-light box-border duration-300"
 >
-  <a href={`blog/${slug}`}>
-    <div class="flex gap-2">
-      {tags.map((tag: string) => <Tag tag={tag} />)}
-    </div>
-    <h1 class="mt-5 mb-1">{title}</h1>
+  <a href={`blog/${slug}`} class="flex h-full flex-col gap-8">
+      <img
 
-    <p class="max-w-prose pl-4">{description}</p>
+        class="bg-primary-light aspect-video w-full rounded-xl border-brand-primary-light bg-brand-primary-light group-hover/card:scale-105 duration-300 transition-all delay-100 group-hover/card:border-brand-accent border-2 border-transparent overflow-hidden group-hover/card:bottom-1 relative bottom-0" 
+        src=`https://picsum.photos/seed/${slug}/900/514`
+      />
+    <div class="flex-grow">
+      <div class="flex justify-start gap-2">
+        {tags.map((tag: string) => <Tag tag={tag} />)}
+      </div>
+      <h1 class="mt-0 mb-0 py-12 text-5xl">{title}</h1>
+    </div>
+    <div class="-m-4 flex justify-between text-brand-white-subtle">
+      <div
+        class="text-brand-text-subtle flex flex-grow border-t-4 border-r-2 border-brand-primary p-5"
+      >
+        12 min
+      </div>
+      <div
+        class="flex flex-grow border-t-4 border-l-2 border-r-2 border-brand-primary p-5"
+      >
+        x
+      </div>
+      <div
+        class="flex flex-grow border-t-4 border-l-2 border-brand-primary p-5"
+      >
+        x
+      </div>
+    </div>
   </a>
 </article>

--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -3,7 +3,7 @@ const { tag } = Astro.props;
 ---
 
 <div
-  class="bg-indigo-800 text-indigo-100 rounded-xl px-4 py-1 uppercase font-extralight tracking-widest shadow-sm shadow-indigo-700/5 cursor-pointer text-sm"
+  class="bg-brand-primary-light text-white-subtle rounded-xl px-4 py-1 uppercase font-light tracking-widest shadow-sm shadow-indigo-700/5 cursor-pointer border-2 border-brand-primary group-hover/card:bg-brand-primary transition-all"
 >
   {tag}
 </div>

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -1,4 +1,5 @@
 ---
+import Tag from '../../components/Tag.astro';
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
@@ -10,12 +11,16 @@ export async function getStaticPaths() {
 }
 const {
   Content,
-  frontmatter: { title },
+  frontmatter: { title, tags },
 } = Astro.props.post;
 ---
 
 <BaseLayout title={title}>
-  <header class="mx-auto max-w-5xl">{title}</header>
+   <a href="/blog" class="bg-brand-secondary text-brand-secondary-light uppercase tracking-wide font-light rounded-xl py-2 px-4 hover:bg-brand-secondary-light transition cursor-pointer hover:text-brand-secondary-dark text-lg">Go back</a>
+  <header class="mx-auto max-w-5xl ">{title}</header>
+  <div class="flex">
+   {tags.map((tag:string)=> <Tag tag={tag}/>)}
+  </div>
   <article class="max-w-5xl mx-auto bg-slate-900 bg-opacity-5">
     <Content />
   </article>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,26 +12,32 @@ const allTags = [
 
 <BaseLayout title="about">
   <h1>Blog</h1>
-  <ul>
+  <div>
+  <input type='text' class="bg-brand-primary-light px-5 py-3 text-xl rounded-xl placeholder:text-white-input" placeholder="Search"/>
+</div>
+<h2 class="text-lg uppercase font-bold  text-brand-white-subtle tracking-wider">Topics</h2>
+  <ul class="flex gap-4 ">
     {
       allTags.map((tag) => (
-        <li class="inline-block mx-2 scale-100">
+        <li>
           <Tag tag={tag} />
         </li>
       ))
     }
   </ul>
-  <h2>All posts</h2>
-  <ul>
+
+  <div class="grid grid-cols-3 gap-6 py-8">
     {
-      allPosts.map(({ frontmatter: { title, description, slug, tags } }) => (
+      allPosts.map(({ frontmatter: { title, description, slug, tags}  }, index) => {
+         return <div class="opacity-0 animate-fade relative flex" style={{animationDelay: `${index*200}ms`}}>
         <ArticleSummaryCard
           title={title}
           tags={tags}
           slug={slug}
           description={description}
         />
-      ))
+</div>
+      })
     }
-  </ul>
+  </d>
 </BaseLayout>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -11,20 +11,16 @@
   }
 
   html {
-    @apply bg-gradient-to-tr from-slate-900 to-slate-800;
+    @apply bg-brand-primary; 
     font-size: 100%;
   }
 
   body{
-    background-size: 40px 40px;
-    background-image:
-      linear-gradient(to right, rgba(255,90,255,.04) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba(255,90,255,.04) 1px, transparent 1px);
   }
 
   * {
     font-family: system-ui, sans-serif;
-    @apply leading-relaxed text-slate-100;
+    @apply leading-relaxed text-brand-white-body;
   }
 
   h1,
@@ -35,7 +31,7 @@
   h6,
   header {
     /* @apply leading-tight  bg-gradient-to-r from-indigo-500 to-blue-300 bg-clip-text text-transparent ; */
-    @apply leading-tight       ;
+    @apply leading-tight text-brand-white-title;
   }
 
   h1,

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,3 +1,5 @@
+const { default: plugin } = require("tailwindcss");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
@@ -15,6 +17,7 @@ module.exports = {
             subtle: "#526074ff",
             title: "#ecededff",
             body: "#fcfcfcff",
+            input: "#64748b",
           },
           secondary: {
             dark: "#2a7275ff",
@@ -26,6 +29,15 @@ module.exports = {
           },
         },
       },
+      animation: {
+        fade: "fadeIn 700ms ease-in-out forwards",
+      },
+      keyframes: (_) => ({
+        fadeIn: {
+          "0%": { opacity: 0, top: "-2rem" },
+          "100%": { opacity: 1, top: "0" },
+        },
+      }),
     },
     plugins: [],
   },


### PR DESCRIPTION
Numerous changes to the style here, this is part of the previous PR to get back to a clean slate to move towards a more atomic, focused PR for better productivity.

Cf #2 

- feat(Numerous-areas!): Multiple changes spanning between styling, SSG routes, etc
- feat(obs-to-blog.js): [WIP] CICD publishing obsidian to blog
- style(lit,-basecss): Drop lit elements, replace toggle switcher with vanilla 'astro'
- feat(/content): Add the first batch of content in order to work on the styling
- style: Set up shiki for code hiligting
- feat(Add-a-SummaryCard-and-a-Tag-component): The summary card is used in the list of blog post, the tag will indicate the category of the content
- feat(SummaryCard,-Tag-components): Add the Summary Card and tag components
- style(tailwind): Add brand colors to tailwind's config
- build(prettier): Set up prettier to autosort tailwind classes
- style(tailwind): Improve tailwind's custom brand colors
- style(Global-styles): Updating styles and colors
